### PR TITLE
style: 아이템의 길이가 길어졌을 경우를 고려한 수정 및 반응형 처리

### DIFF
--- a/src/app/portal/etc/board/page.tsx
+++ b/src/app/portal/etc/board/page.tsx
@@ -74,7 +74,9 @@ const getUserColumns = (currentPage: number, itemsPerPage: number) => [
         className="flex items-center gap-1 hover:underline"
       >
         {row.isPinned ? <Pin className="h-3 w-3 shrink-0" /> : null}
-        <div className="font-medium">{row.title}</div>
+        <div className="w-[250px] truncate overflow-hidden font-medium whitespace-nowrap">
+          {row.title}
+        </div>
       </Link>
     ),
   },

--- a/src/app/portal/reports/daily/page.tsx
+++ b/src/app/portal/reports/daily/page.tsx
@@ -76,7 +76,7 @@ export default function DailyPage() {
 
   return (
     <div className="bg-muted flex flex-col space-y-6 pb-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-6">
         <h1 className="text-3xl font-bold">일일 업무 보고</h1>
         <DateRangePicker
           value={{ from: startDate, to: endDate }}

--- a/src/app/system/etc/board/page.tsx
+++ b/src/app/system/etc/board/page.tsx
@@ -82,7 +82,9 @@ const getUserColumns = (
         href={`/system/etc/board/${row.boardId}`}
         className="hover:underline"
       >
-        <div className="font-medium">{row.title}</div>
+        <div className="w-[250px] truncate overflow-hidden font-medium whitespace-nowrap">
+          {row.title}
+        </div>
       </Link>
     ),
   },

--- a/src/components/portal/report/daily/report-feed.tsx
+++ b/src/components/portal/report/daily/report-feed.tsx
@@ -123,11 +123,15 @@ export function ReportFeed({
                       {report.user?.name?.charAt(0)}
                     </AvatarFallback>
                   </Avatar>
-                  <div className="flex items-center">
+                  <div className="flex items-center gap-1 md:flex-col md:items-start lg:flex-row lg:items-center">
                     <p className="mr-2 text-sm font-medium">
                       {report.user?.name}
                     </p>
-                    <Badge variant="outline">{report.project?.title}</Badge>
+                    <Badge variant="outline">
+                      <div className="max-w-[100px] truncate overflow-hidden whitespace-nowrap lg:max-w-2xs xl:max-w-xl">
+                        {report.project?.title}
+                      </div>
+                    </Badge>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">

--- a/src/components/portal/report/daily/report-form.tsx
+++ b/src/components/portal/report/daily/report-form.tsx
@@ -128,7 +128,9 @@ export function ReportForm({ projectList, onReportCreated }: ReportFormProps) {
                   value={String(proj.projectId)}
                   className="cursor-pointer"
                 >
-                  {proj.title}
+                  <span className="w-[250px] cursor-pointer truncate overflow-hidden text-start whitespace-nowrap">
+                    {proj.title}
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/components/portal/report/daily/report-form.tsx
+++ b/src/components/portal/report/daily/report-form.tsx
@@ -114,7 +114,7 @@ export function ReportForm({ projectList, onReportCreated }: ReportFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="project">프로젝트</Label>
           <Select value={project} onValueChange={setProject} required>

--- a/src/components/portal/researches/projects/timeline/timeline-card.tsx
+++ b/src/components/portal/researches/projects/timeline/timeline-card.tsx
@@ -350,7 +350,9 @@ export default function TimelineCard({
                           <span>{timeline.meetingPlace || '장소 미지정'}</span>
                         </div>
                       </div>
-                      <div className="text-sm">{timeline.summary}</div>
+                      <div className="text-sm whitespace-pre-wrap">
+                        {timeline.summary}
+                      </div>
                       <div className="text-muted-foreground flex items-center gap-1 text-xs">
                         <Paperclip className="h-3 w-3" />
                         {timeline.files && timeline.files.length > 0 ? (

--- a/src/components/system/reports/admin-report-feed.tsx
+++ b/src/components/system/reports/admin-report-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
@@ -27,6 +28,7 @@ export function AdminReportFeed({
 }: {
   filters?: GetReportsByAllUserRequest;
 }) {
+  const router = useRouter();
   const [reports, setReports] = useState<ReportSummary[]>([]);
 
   useEffect(() => {
@@ -72,7 +74,16 @@ export function AdminReportFeed({
                     <p className="mr-2 text-sm font-medium md:pl-2 lg:pl-0">
                       {report.user?.name}
                     </p>
-                    <Badge variant="outline" title={report.project?.title}>
+                    <Badge
+                      variant="outline"
+                      title={report.project?.title}
+                      onClick={() =>
+                        router.push(
+                          `/system/researches/projects/${report.project?.projectId}`,
+                        )
+                      }
+                      className="cursor-pointer"
+                    >
                       <div className="max-w-[120px] truncate overflow-hidden whitespace-nowrap lg:max-w-2xs xl:max-w-xl">
                         {report.project?.title}
                       </div>

--- a/src/components/system/reports/admin-report-feed.tsx
+++ b/src/components/system/reports/admin-report-feed.tsx
@@ -73,7 +73,7 @@ export function AdminReportFeed({
                       {report.user?.name}
                     </p>
                     <Badge variant="outline" title={report.project?.title}>
-                      <div className="truncate overflow-hidden whitespace-nowrap md:max-w-[120px] lg:max-w-none">
+                      <div className="max-w-[120px] truncate overflow-hidden whitespace-nowrap lg:max-w-2xs xl:max-w-xl">
                         {report.project?.title}
                       </div>
                     </Badge>

--- a/src/components/system/reports/filter-controls.tsx
+++ b/src/components/system/reports/filter-controls.tsx
@@ -168,8 +168,9 @@ export function FilterControls({
                   key={proj.projectId}
                   value={String(proj.projectId)}
                   title={proj.title}
+                  className="cursor-pointer"
                 >
-                  <span className="w-[250px] truncate overflow-hidden text-start whitespace-nowrap">
+                  <span className="w-[250px] cursor-pointer truncate overflow-hidden text-start whitespace-nowrap">
                     {proj.title}
                   </span>
                 </SelectItem>
@@ -195,6 +196,7 @@ export function FilterControls({
                   <SelectItem
                     key={userItem.userId}
                     value={String(userItem.userId)}
+                    className="cursor-pointer"
                   >
                     {userItem.name}
                   </SelectItem>


### PR DESCRIPTION
- 일일 업무 보고
    - 어드민
        - 프로젝트 명이 길 경우 css 깨짐 수정
        - 필터 select에 cursor-pointer 설정
        - 프로젝트 클릭시, 해당 페이지로 이동하도록 수정
    - 유저
        - 프로젝트 명이 길 경우 css 깨짐 수정
        - 일일업무보고 피드 아이템 반응형 처리
        - 일일업무보고 폼 반응형 수정
        - 상단 제목과 datepicker 반응형 수정

- 연구&프로젝트
    - 타임라인 summary 줄바꿈도 출력되도록 수정