### PR TITLE
!HOTFIX: created At -> date로 렌더링 수정

### DIFF
--- a/src/components/system/reports/admin-report-feed.tsx
+++ b/src/components/system/reports/admin-report-feed.tsx
@@ -19,6 +19,7 @@ import {
   ReportSummary,
 } from '@/generated-api';
 import { getApiConfig } from '@/lib/config';
+import { formatDateTimeVer2 } from '@/lib/utils';
 
 const reportApi = new AdminReportApi(getApiConfig());
 
@@ -81,10 +82,7 @@ export function AdminReportFeed({
                 </div>
                 <div className="flex items-center gap-2">
                   <p className="text-right text-xs font-medium">
-                    {report.createdAt &&
-                      format(report.createdAt, 'yyyy년 MM월 dd일', {
-                        locale: ko,
-                      })}
+                    {formatDateTimeVer2(report.date!)}
                   </p>
                 </div>
               </div>

--- a/src/components/system/reports/admin-report-feed.tsx
+++ b/src/components/system/reports/admin-report-feed.tsx
@@ -12,8 +12,6 @@ import {
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Paperclip } from 'lucide-react';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
 import {
   AdminReportApi,
   GetReportsByAllUserRequest,


### PR DESCRIPTION
- 일일 업무 보고 어드민 쪽에서 date로 표시되어야 할 필드가 createdAt이 표시되고 있었음
- date로 바꾸고 유틸함수 포털이랑 같은 것으로 바꿈