### PR TITLE
feat: 어드민 휴가 조회/승인/반려 api 연동 및 페이지 수정

### DIFF
--- a/src/app/system/users/leaves/page.tsx
+++ b/src/app/system/users/leaves/page.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 
 export default function LeavesPage() {
   return (
-    <div className="mb-8 flex flex-col">
-      <h1 className="text-3xl font-bold">휴가 관리</h1>
+    <div className="flex flex-col">
+      <h1 className="mb-6 text-3xl font-bold">휴가 관리</h1>
       <LeavesAdmin />
     </div>
   );

--- a/src/app/system/users/leaves/page.tsx
+++ b/src/app/system/users/leaves/page.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 export default function LeavesPage() {
   return (
-    <div className="flex flex-col">
+    <div>
       <h1 className="mb-6 text-3xl font-bold">휴가 관리</h1>
       <LeavesAdmin />
     </div>

--- a/src/components/system/users/leaves/leaves-table.tsx
+++ b/src/components/system/users/leaves/leaves-table.tsx
@@ -1,17 +1,9 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 import {
   Dialog,
   DialogContent,
@@ -22,8 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-import { Check, X, Calendar, User, Building, Users } from 'lucide-react';
-import { TooltipProvider } from '@/components/ui/tooltip';
+import { Check, X, User, Building, Users } from 'lucide-react';
 import {
   Popover,
   PopoverContent,
@@ -38,60 +29,21 @@ import {
 } from '@/components/ui/select';
 import { cn, formatDateTimeVer5, formatDateTimeVer2 } from '@/lib/utils';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
-
-type VacationTypeKey =
-  | 'ANNUAL'
-  | 'HALF_AM'
-  | 'HALF_PM'
-  | 'SPECIAL_HALF_AM'
-  | 'SPECIAL_HALF_PM'
-  | 'SPECIAL_ANNUAL';
-
-type VacationStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
-
-interface Employee {
-  id: string;
-  name: string;
-  email: string;
-  department: string;
-  organization: string;
-  position: string;
-}
-
-interface VacationRequest {
-  id: string;
-  employee: Employee;
-  type: VacationTypeKey;
-  startDate: string;
-  endDate: string;
-  reason?: string;
-  status: VacationStatus;
-  appliedAt: string;
-  processedAt?: string;
-  processedBy?: string;
-  rejectReason?: string;
-}
-
-const vacationTypeLabels: Record<VacationTypeKey, string> = {
-  ANNUAL: '일반 연차',
-  HALF_AM: '일반 반차 (오전)',
-  HALF_PM: '일반 반차 (오후)',
-  SPECIAL_ANNUAL: '특별 연차',
-  SPECIAL_HALF_AM: '특별 반차 (오전)',
-  SPECIAL_HALF_PM: '특별 반차 (오후)',
-};
-
-const statusLabels: Record<VacationStatus, string> = {
-  PENDING: '대기',
-  APPROVED: '승인',
-  REJECTED: '반려',
-};
-
-const statusColors: Record<VacationStatus, string> = {
-  PENDING: 'bg-yellow-100 text-yellow-800',
-  APPROVED: 'bg-green-100 text-green-800',
-  REJECTED: 'bg-red-100 text-red-800',
-};
+import { PaginatedTable } from '@/components/common/paginated-table';
+import {
+  AdminLeaveApi,
+  GetLeaves1StatusEnum,
+  LeaveDetail,
+  UserDetail,
+} from '@/generated-api';
+import { getApiConfig } from '@/lib/config';
+import {
+  leaveStatusColorMap,
+  leaveStatusLabelMap,
+  leaveTyoeLabelMap,
+} from '@/constants/leave-enum';
+import { toast } from 'sonner';
+import { positionLabelMap } from '@/constants/position-enum';
 
 // 자주 사용하는 반려사유 템플릿 추가
 const rejectReasonTemplates = [
@@ -102,102 +54,9 @@ const rejectReasonTemplates = [
   '휴가 신청 기간이 너무 짧습니다.',
 ];
 
-// 샘플 데이터
-const sampleRequests: VacationRequest[] = [
-  {
-    id: '1',
-    employee: {
-      id: 'emp1',
-      name: '김철수',
-      email: 'kim.cs@company.com',
-      department: '개발팀',
-      organization: '기술본부',
-      position: '선임개발자',
-    },
-    type: 'ANNUAL',
-    startDate: '2024-02-15',
-    endDate: '2024-02-16',
-    status: 'PENDING',
-    appliedAt: '2024-02-01T09:00:00Z',
-  },
-  {
-    id: '2',
-    employee: {
-      id: 'emp2',
-      name: '이영희',
-      email: 'lee.yh@company.com',
-      department: '마케팅팀',
-      organization: '영업본부',
-      position: '마케팅매니저',
-    },
-    type: 'SPECIAL_ANNUAL',
-    startDate: '2024-02-20',
-    endDate: '2024-02-20',
-    reason:
-      '가족 경조사로 인한 특별휴가 신청입니다. 할머니 장례식에 참석해야 하며, 지방에 있어 이동시간을 고려하여 하루 종일 휴가가 필요합니다.',
-    status: 'PENDING',
-    appliedAt: '2024-02-02T14:30:00Z',
-  },
-  {
-    id: '3',
-    employee: {
-      id: 'emp3',
-      name: '박민수',
-      email: 'park.ms@company.com',
-      department: '영업팀',
-      organization: '영업본부',
-      position: '영업대리',
-    },
-    type: 'HALF_AM',
-    startDate: '2024-02-10',
-    endDate: '2024-02-10',
-    status: 'APPROVED',
-    appliedAt: '2024-01-28T11:15:00Z',
-    processedAt: '2024-01-29T09:00:00Z',
-    processedBy: '관리자',
-  },
-  {
-    id: '4',
-    employee: {
-      id: 'emp4',
-      name: '정수진',
-      email: 'jung.sj@company.com',
-      department: '인사팀',
-      organization: '경영지원본부',
-      position: '인사담당자',
-    },
-    type: 'SPECIAL_HALF_PM',
-    startDate: '2024-02-08',
-    endDate: '2024-02-08',
-    reason: '정기 건강검진 및 병원 진료',
-    status: 'REJECTED',
-    appliedAt: '2024-01-25T16:45:00Z',
-    processedAt: '2024-01-26T10:30:00Z',
-    processedBy: '관리자',
-    rejectReason:
-      '해당 날짜에 중요한 회의가 예정되어 있어 오후 반차 승인이 어렵습니다. 다른 날짜로 변경 후 재신청 부탁드립니다.',
-  },
-  {
-    id: '5',
-    employee: {
-      id: 'emp5',
-      name: '최동욱',
-      email: 'choi.dw@company.com',
-      department: '개발팀',
-      organization: '기술본부',
-      position: '주임개발자',
-    },
-    type: 'ANNUAL',
-    startDate: '2024-02-12',
-    endDate: '2024-02-14',
-    status: 'APPROVED',
-    appliedAt: '2024-01-30T13:20:00Z',
-    processedAt: '2024-01-31T08:45:00Z',
-    processedBy: '관리자',
-  },
-];
+const leaveApi = new AdminLeaveApi(getApiConfig());
 
-function UserProfilePopover({ employee }: { employee: Employee }) {
+function UserProfilePopover({ employee }: { employee: UserDetail }) {
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -207,7 +66,7 @@ function UserProfilePopover({ employee }: { employee: Employee }) {
               className={cn('aspect-square h-9 w-9 rounded-full border-1')}
             >
               <AvatarImage
-                src="/default-profile-image.svg"
+                src={employee.profileImageUrl || '/default-profile-image.svg'}
                 alt="tmp"
                 className="object-cover"
               />
@@ -225,7 +84,7 @@ function UserProfilePopover({ employee }: { employee: Employee }) {
               className={cn('aspect-square h-12 w-12 rounded-full border-1')}
             >
               <AvatarImage
-                src="/default-profile-image.svg"
+                src={employee.profileImageUrl || '/default-profile-image.svg'}
                 alt="tmp"
                 className="object-cover"
               />
@@ -239,17 +98,19 @@ function UserProfilePopover({ employee }: { employee: Employee }) {
             <div className="flex items-center gap-2 text-sm">
               <Building className="text-muted-foreground h-4 w-4" />
               <span className="font-medium">기관:</span>
-              <span>{employee.organization}</span>
+              <span>{employee.organization ? employee.organization : ''}</span>
             </div>
             <div className="flex items-center gap-2 text-sm">
               <Users className="text-muted-foreground h-4 w-4" />
               <span className="font-medium">부서:</span>
-              <span>{employee.department}</span>
+              <span>{employee.department ? employee.department : ''}</span>
             </div>
             <div className="flex items-center gap-2 text-sm">
               <User className="text-muted-foreground h-4 w-4" />
               <span className="font-medium">구분:</span>
-              <span>{employee.position}</span>
+              <span>
+                {employee.position ? positionLabelMap[employee.position] : ''}
+              </span>
             </div>
           </div>
         </div>
@@ -271,7 +132,7 @@ function RejectDialog({
 }: {
   isOpen: boolean;
   onClose: () => void;
-  selectedRequest: VacationRequest | null;
+  selectedRequest: LeaveDetail | null;
   rejectReason: string;
   setRejectReason: (reason: string) => void;
   selectedTemplate: string;
@@ -301,17 +162,20 @@ function RejectDialog({
                   )}
                 >
                   <AvatarImage
-                    src="/default-profile-image.svg"
-                    alt="tmp"
+                    src={
+                      selectedRequest.user?.profileImageUrl ||
+                      '/default-profile-image.svg'
+                    }
+                    alt={selectedRequest.user?.name}
                     className="object-cover"
                   />
                 </Avatar>
                 <div>
                   <h4 className="text-foreground text-lg font-semibold">
-                    {selectedRequest.employee.name}
+                    {selectedRequest.user?.name}
                   </h4>
                   <p className="text-muted-foreground text-sm">
-                    {selectedRequest.employee.email}
+                    {selectedRequest.user?.email}
                   </p>
                 </div>
               </div>
@@ -319,17 +183,29 @@ function RejectDialog({
                 <div className="flex items-center gap-2">
                   <Building className="text-muted-foreground h-4 w-4" />
                   <span className="font-medium">기관:</span>
-                  <span>{selectedRequest.employee.organization}</span>
+                  <span>
+                    {selectedRequest.user?.organization
+                      ? selectedRequest.user?.organization
+                      : ''}
+                  </span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Users className="text-muted-foreground h-4 w-4" />
                   <span className="font-medium">부서:</span>
-                  <span>{selectedRequest.employee.department}</span>
+                  <span>
+                    {selectedRequest.user?.department
+                      ? selectedRequest.user?.department
+                      : ''}
+                  </span>
                 </div>
                 <div className="flex items-center gap-2">
                   <User className="text-muted-foreground h-4 w-4" />
                   <span className="font-medium">구분:</span>
-                  <span>{selectedRequest.employee.position}</span>
+                  <span>
+                    {selectedRequest.user?.position
+                      ? positionLabelMap[selectedRequest.user?.position]
+                      : ''}
+                  </span>
                 </div>
               </div>
             </div>
@@ -340,15 +216,23 @@ function RejectDialog({
                 <div>
                   <span>휴가 종류:</span>
                   <span className="ml-2">
-                    {vacationTypeLabels[selectedRequest.type]}
+                    {leaveTyoeLabelMap[selectedRequest.type || 'ANNUAL']}
                   </span>
                 </div>
                 <div>
                   <span>휴가 기간:</span>
                   <span className="ml-2">
-                    {selectedRequest.startDate === selectedRequest.endDate
-                      ? formatDateTimeVer2(selectedRequest.startDate)
-                      : `${formatDateTimeVer2(selectedRequest.startDate)} ~ ${formatDateTimeVer2(selectedRequest.endDate)}`}
+                    {(() => {
+                      const { startDate, endDate } = selectedRequest;
+
+                      if (!startDate && !endDate) return '-';
+                      // if (!startDate) return formatDateTimeVer2(endDate!);
+                      if (!endDate) return formatDateTimeVer2(startDate!);
+                      if (startDate === endDate)
+                        return formatDateTimeVer2(startDate!);
+
+                      return `${formatDateTimeVer2(startDate!)} ~ ${formatDateTimeVer2(endDate!)}`;
+                    })()}
                   </span>
                 </div>
               </div>
@@ -473,204 +357,200 @@ function ReasonDisplay({ reason }: { reason?: string }) {
   );
 }
 
-function LeavesTable({
-  data,
-  handleApprove,
-  handleReject,
+const getLeaveColumns = ({
+  onApprove,
+  onReject,
 }: {
-  data: VacationRequest[];
-  handleApprove: (id: string) => void;
-  handleReject: (request: VacationRequest) => void;
-}) {
-  return (
-    <TooltipProvider>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow className="hover:bg-transparent">
-              <TableHead className="min-w-[120px] pl-14">신청자</TableHead>
-              <TableHead className="min-w-[140px] text-center">
-                휴가 종류
-              </TableHead>
-              <TableHead className="min-w-[140px] text-center">기간</TableHead>
-              <TableHead className="min-w-[150px] text-center">사유</TableHead>
-              <TableHead className="min-w-[80px] text-center">상태</TableHead>
-              <TableHead className="min-w-[140px] text-center">
-                신청일
-              </TableHead>
-              <TableHead className="min-w-[160px] text-center"> </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {data.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={8}
-                  className="text-muted-foreground py-12 text-center"
-                >
-                  <div className="flex flex-col items-center gap-2">
-                    <Calendar className="text-muted-foreground/50 h-8 w-8" />
-                    <span>해당하는 휴가 신청이 없습니다.</span>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ) : (
-              data.map((request) => (
-                <TableRow
-                  key={request.id}
-                  className="hover:bg-muted/30 transition-colors"
-                >
-                  <TableCell className="min-w-[120px]">
-                    <UserProfilePopover employee={request.employee} />
-                  </TableCell>
-                  <TableCell className="min-w-[140px] text-center">
-                    <Badge variant="outline" className="whitespace-nowrap">
-                      {vacationTypeLabels[request.type]}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="min-w-[140px] truncate text-center">
-                    {request.startDate === request.endDate
-                      ? formatDateTimeVer2(request.startDate)
-                      : `${formatDateTimeVer2(request.startDate)} ~ ${formatDateTimeVer2(request.endDate)}`}
-                  </TableCell>
-                  <TableCell className="min-w-[150px] text-center">
-                    <ReasonDisplay reason={request.reason} />
-                  </TableCell>
-                  <TableCell className="min-w-[80px] text-center">
-                    {request.status === 'REJECTED' && request.rejectReason ? (
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            className="h-auto p-0 hover:bg-transparent"
-                          >
-                            <Badge
-                              className={`${statusColors[request.status]} cursor-pointer font-medium transition-opacity hover:opacity-80`}
-                            >
-                              {statusLabels[request.status]}
-                            </Badge>
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-80" align="center">
-                          <div className="space-y-2">
-                            <h4 className="text-sm font-semibold text-red-800">
-                              반려 사유
-                            </h4>
-                            <div className="rounded-lg bg-red-50 p-3">
-                              <p className="text-sm leading-relaxed whitespace-pre-wrap text-red-800">
-                                {request.rejectReason}
-                              </p>
-                            </div>
-                          </div>
-                        </PopoverContent>
-                      </Popover>
-                    ) : (
-                      <Badge
-                        className={`${statusColors[request.status]} font-medium`}
-                      >
-                        {statusLabels[request.status]}
-                      </Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="min-w-[140px] truncate text-center">
-                    {formatDateTimeVer5(request.appliedAt)}
-                  </TableCell>
-                  <TableCell className="min-w-[160px]">
-                    <div className="flex items-center justify-center gap-2">
-                      {request.status === 'PENDING' ? (
-                        <>
-                          <Button
-                            size="sm"
-                            onClick={() => handleApprove(request.id)}
-                          >
-                            <Check className="mr-1 h-3 w-3" />
-                            승인
-                          </Button>
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => handleReject(request)}
-                          >
-                            <X className="mr-1 h-3 w-3" />
-                            반려
-                          </Button>
-                        </>
-                      ) : (
-                        <div className="text-muted-foreground space-y-1 text-xs">
-                          {request.processedAt && (
-                            <div className="flex items-center gap-1 truncate">
-                              처리일시:{' '}
-                              {formatDateTimeVer5(request.processedAt)}
-                            </div>
-                          )}
-                          {request.processedBy && (
-                            <div className="text-muted-foreground text-xs">
-                              처리자: {request.processedBy}
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
-    </TooltipProvider>
-  );
-}
+  onApprove: (leaveId: number) => void;
+  onReject: (row: LeaveDetail) => void;
+}) => [
+  {
+    label: '신청자',
+    className: 'w-[200px]',
+    cell: (row: LeaveDetail) =>
+      row.user ? (
+        <UserProfilePopover employee={row.user} />
+      ) : (
+        <span className="text-muted-foreground">알 수 없음</span>
+      ),
+  },
+  {
+    label: '휴가 종류',
+    className: 'text-center w-[140px]',
+    cell: (row: LeaveDetail) => (
+      <Badge variant="outline">{leaveTyoeLabelMap[row.type || 'ANNUAL']}</Badge>
+    ),
+  },
+  {
+    label: '기간',
+    className: 'text-center w-[250px]',
+    cell: (row: LeaveDetail) => {
+      const { startDate, endDate } = row;
+
+      if (!startDate && !endDate) return '-';
+
+      const start = startDate ? formatDateTimeVer2(startDate) : '';
+      const end = endDate ? formatDateTimeVer2(endDate) : '';
+
+      if (start && end) {
+        return `${start} ~ ${end}`;
+      }
+
+      return start || end;
+    },
+  },
+  {
+    label: '사유',
+    className: 'w-[350px] text-center',
+    cell: (row: LeaveDetail) => <ReasonDisplay reason={row.reason} />,
+  },
+  {
+    label: '상태',
+    className: 'w-[80px] text-center',
+    cell: (row: LeaveDetail) => {
+      const status = row.status ?? 'PENDING';
+
+      return row.status === 'REJECTED' && row.rejectReason ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" className="h-auto p-0 hover:bg-transparent">
+              <Badge
+                className={`${leaveStatusColorMap[status]} cursor-pointer font-medium transition-opacity hover:opacity-80`}
+              >
+                {leaveStatusLabelMap[status]}
+              </Badge>
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80" align="center">
+            <div className="space-y-2">
+              <h4 className="text-sm font-semibold text-red-800">반려 사유</h4>
+              <div className="rounded-lg bg-red-50 p-3">
+                <p className="text-sm leading-relaxed whitespace-pre-wrap text-red-800">
+                  {row.rejectReason}
+                </p>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      ) : (
+        <Badge className={`${leaveStatusColorMap[status]} font-medium`}>
+          {leaveStatusLabelMap[status]}
+        </Badge>
+      );
+    },
+  },
+  {
+    label: '신청일',
+    className: 'text-center w-[180px]',
+    cell: (row: LeaveDetail) =>
+      row.applicatedAt ? formatDateTimeVer5(row.applicatedAt) : '-',
+  },
+  {
+    label: '',
+    className: 'text-center w-[200px]',
+    cell: (row: LeaveDetail) =>
+      row.status === 'PENDING' ? (
+        <div className="flex justify-center gap-2">
+          <Button
+            size="sm"
+            onClick={() => row.leaveId && onApprove(row.leaveId)}
+          >
+            <Check className="mr-1 h-3 w-3" />
+            승인
+          </Button>
+          <Button variant="destructive" size="sm" onClick={() => onReject(row)}>
+            <X className="mr-1 h-3 w-3" />
+            반려
+          </Button>
+        </div>
+      ) : (
+        <div className="text-muted-foreground space-y-1 text-xs">
+          {row.processedAt && (
+            <div className="flex items-center gap-1 truncate">
+              처리일시: {formatDateTimeVer5(row.processedAt)}
+            </div>
+          )}
+          {row.processor?.name && (
+            <div className="flex items-center gap-1 truncate">
+              처리자: {row.processor.name}
+            </div>
+          )}
+        </div>
+      ),
+  },
+];
 
 export default function LeavesAdmin() {
-  const [requests, setRequests] = useState<VacationRequest[]>(sampleRequests);
-  const [selectedRequest, setSelectedRequest] =
-    useState<VacationRequest | null>(null);
+  const [status, setStatus] = useState<GetLeaves1StatusEnum | undefined>(
+    undefined,
+  );
+  const [requests, setRequests] = useState<LeaveDetail[]>([]);
+  const [selectedRequest, setSelectedRequest] = useState<LeaveDetail | null>(
+    null,
+  );
   const [rejectReason, setRejectReason] = useState('');
   const [isRejectDialogOpen, setIsRejectDialogOpen] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState('');
 
-  const filterRequestsByStatus = (status?: VacationStatus) => {
-    if (!status) return requests;
-    return requests.filter((request) => request.status === status);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const [totalPage, setTotalPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const fetchLeaves = async () => {
+    setLoading(true);
+    try {
+      const res = await leaveApi.getLeaves1({
+        status,
+        page: currentPage - 1,
+        size: itemsPerPage,
+      });
+      setRequests(res.leaves || []);
+      setTotalPage(res.totalPage ?? 1);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handleApprove = (requestId: string) => {
-    setRequests((prev) =>
-      prev.map((request) =>
-        request.id === requestId
-          ? {
-              ...request,
-              status: 'APPROVED' as VacationStatus,
-              processedAt: new Date().toISOString(),
-              processedBy: '관리자',
-            }
-          : request,
-      ),
-    );
+  useEffect(() => {
+    fetchLeaves();
+  }, [status, currentPage, itemsPerPage]);
+
+  const handleApprove = async (leaveId: number) => {
+    try {
+      await leaveApi.approveLeave({ leaveId });
+      await fetchLeaves();
+
+      toast.success('휴가 신청이 성공적으로 승인되었습니다.');
+    } catch (e) {
+      console.error('휴가 승인 실패:', e);
+    }
   };
 
-  const handleReject = (request: VacationRequest) => {
+  const handleReject = (request: LeaveDetail) => {
     setSelectedRequest(request);
     setIsRejectDialogOpen(true);
   };
 
-  const confirmReject = () => {
+  const confirmReject = async () => {
     if (!selectedRequest) return;
 
-    setRequests((prev) =>
-      prev.map((request) =>
-        request.id === selectedRequest.id
-          ? {
-              ...request,
-              status: 'REJECTED' as VacationStatus,
-              rejectReason: rejectReason.trim(),
-              processedAt: new Date().toISOString(),
-              processedBy: '관리자',
-            }
-          : request,
-      ),
-    );
+    try {
+      await leaveApi.rejectLeave({
+        leaveId: selectedRequest.leaveId!,
+        rejectLeaveRequest: {
+          rejectReason: rejectReason.trim(),
+        },
+      });
+
+      await fetchLeaves();
+
+      toast.success('휴가 신청이 성공적으로 반려되었습니다.');
+    } catch (e) {
+      console.error('휴가 반려 실패:', e);
+    }
 
     setIsRejectDialogOpen(false);
     setSelectedRequest(null);
@@ -678,91 +558,141 @@ export default function LeavesAdmin() {
     setSelectedTemplate('');
   };
 
-  const allRequests = filterRequestsByStatus();
-  const pendingRequests = filterRequestsByStatus('PENDING');
-  const approvedRequests = filterRequestsByStatus('APPROVED');
-  const rejectedRequests = filterRequestsByStatus('REJECTED');
-
   return (
-    <div className="w-full py-6">
+    <div>
       <Tabs defaultValue="all" className="space-y-4">
         <TabsList className="grid w-full grid-cols-4">
-          <TabsTrigger value="all" className="group flex items-center gap-2">
+          <TabsTrigger
+            value="all"
+            onClick={() => {
+              setStatus(undefined);
+              setCurrentPage(1);
+            }}
+            className="group flex items-center gap-2"
+          >
             전체
-            <Badge
-              variant="secondary"
-              className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white"
-            >
-              {allRequests.length}
-            </Badge>
+            {/* <Badge */}
+            {/*   variant="secondary" */}
+            {/*   className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white" */}
+            {/* > */}
+            {/*   {requests.length} */}
+            {/* </Badge> */}
           </TabsTrigger>
           <TabsTrigger
             value="pending"
+            onClick={() => {
+              setStatus(GetLeaves1StatusEnum.Pending);
+              setCurrentPage(1);
+            }}
             className="group flex items-center gap-2"
           >
             대기
-            <Badge
-              variant="secondary"
-              className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white"
-            >
-              {pendingRequests.length}
-            </Badge>
+            {/* <Badge */}
+            {/*   variant="secondary" */}
+            {/*   className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white" */}
+            {/* > */}
+            {/*   {requests.length} */}
+            {/* </Badge> */}
           </TabsTrigger>
           <TabsTrigger
             value="approved"
+            onClick={() => {
+              setStatus(GetLeaves1StatusEnum.Approved);
+              setCurrentPage(1);
+            }}
             className="group flex items-center gap-2"
           >
             승인
-            <Badge
-              variant="secondary"
-              className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white"
-            >
-              {approvedRequests.length}
-            </Badge>
+            {/* <Badge */}
+            {/*   variant="secondary" */}
+            {/*   className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white" */}
+            {/* > */}
+            {/*   {requests.length} */}
+            {/* </Badge> */}
           </TabsTrigger>
           <TabsTrigger
             value="rejected"
+            onClick={() => {
+              setStatus(GetLeaves1StatusEnum.Rejected);
+              setCurrentPage(1);
+            }}
             className="group flex items-center gap-2"
           >
             반려
-            <Badge
-              variant="secondary"
-              className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white"
-            >
-              {rejectedRequests.length}
-            </Badge>
+            {/* <Badge */}
+            {/*   variant="secondary" */}
+            {/*   className="group-data-[state=inactive]:text-muted-foreground ml-1 group-data-[state=inactive]:bg-white" */}
+            {/* > */}
+            {/*   {requests.length} */}
+            {/* </Badge> */}
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="all" className="space-y-4">
-          <LeavesTable
-            data={allRequests}
-            handleApprove={handleApprove}
-            handleReject={handleReject}
+          <PaginatedTable
+            data={requests}
+            rowKey={(row) => String(row.leaveId)}
+            columns={getLeaveColumns({
+              onApprove: handleApprove,
+              onReject: handleReject,
+            })}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={setItemsPerPage}
+            totalPage={totalPage}
+            loading={loading}
           />
         </TabsContent>
 
         <TabsContent value="pending" className="space-y-4">
-          <LeavesTable
-            data={pendingRequests}
-            handleApprove={handleApprove}
-            handleReject={handleReject}
+          <PaginatedTable
+            data={requests}
+            rowKey={(row) => String(row.leaveId)}
+            columns={getLeaveColumns({
+              onApprove: handleApprove,
+              onReject: handleReject,
+            })}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={setItemsPerPage}
+            totalPage={totalPage}
+            loading={loading}
           />
         </TabsContent>
 
         <TabsContent value="approved" className="space-y-4">
-          <LeavesTable
-            data={approvedRequests}
-            handleApprove={handleApprove}
-            handleReject={handleReject}
+          <PaginatedTable
+            data={requests}
+            rowKey={(row) => String(row.leaveId)}
+            columns={getLeaveColumns({
+              onApprove: handleApprove,
+              onReject: handleReject,
+            })}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={setItemsPerPage}
+            totalPage={totalPage}
+            loading={loading}
           />
         </TabsContent>
 
         <TabsContent value="rejected" className="space-y-4">
-          <LeavesTable
-            data={rejectedRequests}
-            handleApprove={handleApprove}
-            handleReject={handleReject}
+          <PaginatedTable
+            data={requests}
+            rowKey={(row) => String(row.leaveId)}
+            columns={getLeaveColumns({
+              onApprove: handleApprove,
+              onReject: handleReject,
+            })}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={setItemsPerPage}
+            totalPage={totalPage}
+            loading={loading}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
- 어드민 휴가 조회/승인/반려 api 연동
    -  탭 트리거에 있는 전체/대기/승인/반려 항목의 개수는 페이지네이션으로 인해 계산의 어려움이 있어 잠시 주석 처리 하였습니다.

- 어드민 휴가 관리 페이지 수정
    - 페이지 내부에 페이지네이션이 추가됨으로써 페이지 내부 코드를 수정하였습니다.